### PR TITLE
ci: make tests run correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
   only:
     - master
 script:
-  - cargo test --verbose -- --ignored
+  - cargo test --verbose
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
This Pull Request removes the `--ignored` flag, that only runs `ignored` tests.

We should run all non ignored tests on CI.

Fixes: #4 