### PR TITLE
cargo: bump version to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spy"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Alex Pikalov <alex.pikalov.khar@gmail.com>"]
 description = "Rust spy functions for testing purposes"
 documentation = "https://docs.rs/spy"


### PR DESCRIPTION
This Pull Request bumps the version on `Cargo.toml`, from `0.1.0` to `0.1.1`.

This should be a `patch` because the people that are using `0.1.0` have a broken package, so they should have the fix via `patch` update.

🚨 **This code does not fixes the issue! A `cargo publish` should be executed after the code is merged!** 🚨 

Related issue: #6 